### PR TITLE
feat(form): add inline validation with error messages

### DIFF
--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -523,6 +523,26 @@ body {
   margin-bottom: 8px;
 }
 
+/* Form Field Error States */
+.field-error {
+  display: block;
+  color: var(--error-color);
+  font-size: 0.75rem;
+  margin-top: 4px;
+  min-height: 1rem;
+}
+
+.input-field.error,
+.input-select.error {
+  border-color: var(--error-color);
+}
+
+.input-field.error:focus,
+.input-select.error:focus {
+  border-color: var(--error-color);
+  box-shadow: 0 0 0 3px rgba(211, 47, 47, 0.1);
+}
+
 /* Snackbar */
 .snackbar {
   position: fixed;

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -160,30 +160,43 @@
             <span class="material-icons">close</span>
           </button>
         </div>
-        <form id="expenseForm">
+        <form id="expenseForm" novalidate>
           <input type="hidden" id="expenseId">
           <div class="form-group">
             <label for="description" class="input-label">Description *</label>
             <input type="text" id="description" class="input-field" required 
-                   placeholder="e.g., Lunch at restaurant">
+                   maxlength="200"
+                   placeholder="e.g., Lunch at restaurant"
+                   aria-required="true"
+                   aria-describedby="descriptionError">
+            <span id="descriptionError" class="field-error" role="alert"></span>
           </div>
           <div class="form-group">
             <label for="amount" class="input-label">Amount *</label>
             <div class="input-with-prefix">
               <span class="input-prefix">$</span>
               <input type="number" id="amount" class="input-field" required 
-                     min="0" step="0.01" placeholder="0.00">
+                     min="0.01" max="999999.99" step="0.01" placeholder="0.00"
+                     aria-required="true"
+                     aria-describedby="amountError">
             </div>
+            <span id="amountError" class="field-error" role="alert"></span>
           </div>
           <div class="form-group">
             <label for="category" class="input-label">Category *</label>
-            <select id="category" class="input-select" required>
+            <select id="category" class="input-select" required
+                    aria-required="true"
+                    aria-describedby="categoryError">
               <option value="">Select a category</option>
             </select>
+            <span id="categoryError" class="field-error" role="alert"></span>
           </div>
           <div class="form-group">
             <label for="date" class="input-label">Date *</label>
-            <input type="date" id="date" class="input-field" required>
+            <input type="date" id="date" class="input-field" required
+                   aria-required="true"
+                   aria-describedby="dateError">
+            <span id="dateError" class="field-error" role="alert"></span>
           </div>
           <div class="modal-actions">
             <button type="button" class="btn btn-text" onclick="closeModal()">Cancel</button>


### PR DESCRIPTION
## Summary
Add client-side form validation with inline error messages and ARIA accessibility.

Closes #6

## Changes
### HTML (`index.html`)
- Added `novalidate` attribute to form (to use custom validation)
- Added HTML5 constraints: `maxlength="200"` (description), `min="0.01"` `max="999999.99"` (amount)
- Added inline error containers (`#descriptionError`, `#amountError`, `#categoryError`, `#dateError`)
- Added ARIA attributes: `aria-required`, `aria-describedby` linking fields to error containers
- Error containers include `role="alert"` for screen readers

### CSS (`styles.css`)
- Added `.field-error` class for error message styling (red text, small font)
- Added `.input-field.error` and `.input-select.error` for red border on invalid fields
- Added focus state for error fields with red box-shadow

### JavaScript (`app.js`)
- Added error container element references
- Implemented `validateForm(data)` returning `{field: message}` errors object
  - Validates description: required, max 200 chars
  - Validates amount: required, > 0, ≤ 999,999.99
  - Validates category: required
  - Validates date: required, no future dates
- Implemented `showFieldError(field, message)` - adds error class and displays message
- Implemented `clearFieldError(field)` - removes error class and clears message
- Implemented `clearAllFieldErrors()` - clears all field errors
- Implemented `validateFieldOnBlur(field)` - validates single field on blur
- Added blur event listeners on all form fields
- Updated `handleFormSubmit()` to validate and block submission if errors
- Updated `closeModal()` to clear all field errors
- Added new functions to exports for testing

## Test Criteria
- [x] Description limited to 200 characters
- [x] Amount limited to 999,999.99
- [x] Error containers exist with `aria-describedby` links
- [x] Invalid fields show red border (`.error` class)
- [x] Error messages appear below invalid fields
- [x] Validation triggers on blur
- [x] Form submit blocked when validation fails
- [x] Future dates rejected with error message

## Commit Message
```
feat(form): add inline validation with error messages
```